### PR TITLE
Fix vdiskcopy and move blockstor binaries to /bin

### DIFF
--- a/buildscripts/builder-blockstor.sh
+++ b/buildscripts/builder-blockstor.sh
@@ -19,19 +19,20 @@ mkdir -p /gopath
 export GOPATH=/gopath
 BLOCKSTOR=$GOPATH/src/github.com/g8os/blockstor
 
-go get -v -d github.com/g8os/blockstor/nbdserver
-go get -v -d github.com/g8os/blockstor/cmd/copyvdisk
+go get -u -v -d github.com/g8os/blockstor/nbdserver
+go get -u -v -d github.com/g8os/blockstor/cmd/copyvdisk
 
 cd $BLOCKSTOR
+mkdir -p build/bin
 
-git fetch origin "${branch}:${branch}" || true
-git checkout "${branch}" || true
+git fetch origin || true
+git checkout -B "${branch}" origin/${branch} || true
 
 cd $BLOCKSTOR/nbdserver
-CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
+CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ../build/bin/nbdserver
 
 cd $BLOCKSTOR/cmd/copyvdisk
-CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
+CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ../../build/bin/copyvdisk
 
 mkdir -p /tmp/archives/
-tar -czf "/tmp/archives/blockstor-${branch}.tar.gz" -C $BLOCKSTOR/nbdserver nbdserver -C $BLOCKSTOR/cmd/copyvdisk copyvdisk
+tar -czf "/tmp/archives/blockstor-${branch}.tar.gz" -C $BLOCKSTOR/build .

--- a/templates/nbdserver/actions.py
+++ b/templates/nbdserver/actions.py
@@ -17,7 +17,7 @@ def is_running(client, key):
     try:
         for process in client.job.list():
             arguments = process['cmd']['arguments']
-            if 'name' in arguments and arguments['name'] == '/nbdserver' and \
+            if 'name' in arguments and arguments['name'] == '/bin/nbdserver' and \
                key in arguments['args']:
                 return process
         return False
@@ -41,7 +41,7 @@ def install(job):
     socketpath = '/server.socket.{id}'.format(id=service.name)
     if not is_running(container, service.name):
         container.system(
-            '/nbdserver \
+            '/bin/nbdserver \
             -protocol unix \
             -address "{socketpath}" \
             -export {id} \


### PR DESCRIPTION
Take masterardb for vdiskcopy from /etc/g8os/g8os.toml
Move all binaries in blockstore flist to /bin

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>